### PR TITLE
update dependencies and Java version for Spring Boot 3.0 support

### DIFF
--- a/.github/workflows/run-with-maven.yml
+++ b/.github/workflows/run-with-maven.yml
@@ -39,10 +39,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Set up JDK 8
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
-          java-version: '8'
+          java-version: '17'
           distribution: 'adopt'
           cache: maven
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ all without writing more code, because you already have all information you need
   * [Changing serialization by using Jackson annotations](#changing-serialization-by-using-jackson-annotations)
   * [Changing serialization by using a custom ObjectMapper](#changing-serialization-by-using-a-custom-objectmapper)
 * [Changes](#changes)
+  * [3.0.0](#300)
   * [2.0.6](#206)
   * [2.0.5](#205)
   * [2.0.4](#204)
@@ -318,6 +319,11 @@ public class TimeMachine {
 If you want to use your own ObjectMapper for serialization, you can exchange the used default ObjectMapper by calling `setGlobalObjectMapper`. To reset to the default ObjectMapper, you can use `resetGlobalObjectMapper` at any time.
 
 ## Changes
+
+### 3.0.0
+
+* **Breaking change** updates Dependencies to new major versions (Spring and Slf4j) and updates to Java 17
+  * note that Spring remains an optional dependency and will not be included if you're not using structred-logging, but are not using Spring
 
 ### 2.0.6
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,29 +29,29 @@
     </developers>
 
     <properties>
-        <project.version>2.0.2-SNAPSHOT</project.version>
+        <project.version>3.0.1-SNAPSHOT</project.version>
 
-        <java.version>1.8</java.version>
+        <java.version>17</java.version>
         <encoding>UTF-8</encoding>
         <logstash-logback-encoder.version>7.2</logstash-logback-encoder.version>
-        <lombok.version>1.18.24</lombok.version>
-        <slf4j.version>1.7.30</slf4j.version>
-        <logback.version>1.2.3</logback.version>
-        <spring.version>5.3.23</spring.version>
-        <spring.boot.version>2.7.4</spring.boot.version>
-        <junit-jupiter.version>5.7.0</junit-jupiter.version>
-        <assertj.version>3.17.2</assertj.version>
-        <mockito.version>3.5.13</mockito.version>
-        <log-capture.version>3.5.0</log-capture.version>
+        <lombok.version>1.18.26</lombok.version>
+        <slf4j.version>2.0.6</slf4j.version>
+        <logback.version>1.4.5</logback.version>
+        <spring.version>6.0.5</spring.version>
+        <spring.boot.version>3.0.2</spring.boot.version>
+        <junit-jupiter.version>5.9.2</junit-jupiter.version>
+        <assertj.version>3.24.2</assertj.version>
+        <mockito.version>5.1.1</mockito.version>
+        <log-capture.version>3.6.1</log-capture.version>
         <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
-        <maven-javadoc-plugin.version>3.3.2</maven-javadoc-plugin.version>
+        <maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
-        <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
+        <maven-checkstyle-plugin.version>3.2.1</maven-checkstyle-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
-        <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
-        <checkstyle.version>8.45.1</checkstyle.version>
+        <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
+        <checkstyle.version>10.7.0</checkstyle.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This should not be merged until it is verified to work with Spring Boot 3.0 in our own projects.